### PR TITLE
Fix highlighting for 'diff' filetype

### DIFF
--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -238,6 +238,12 @@ M.load_syntax = function(palette)
             fg = palette.black,
             bg = palette.aqua,
         },
+        diffAdded = {
+            fg = palette.green,
+        },
+        diffRemoved = {
+            fg = palette.pink,
+        },
         Folded = {
             fg = palette.grey,
             bg = palette.base3,


### PR DESCRIPTION
By default, `syntax/diff.vim` from the neovim runtime uses highlights for `Identifier` and `Special` for added and removed lines:

```vim
hi def link diffAdded		Identifier
hi def link diffRemoved		Special
```

As these are both highlighted in white in monokai.nvim, it makes diff highlighting display everything as plain white.

Fix this by adding explicit highlights for `diffAdded` and `diffRemoved` in appropriate colors.