### PR TITLE
Add option to disable italics

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ monokai.setup {
 }
 ```
 
+With `italics` option (`true` by default), you can disable italic used by default in style for some groups (`Function`, `Keyword`, `Comment`...).
+
+```
+require('monokai').setup { italics = false }
+```
+
 ## Extras
 
 Extra color configs for **Kitty**, **Alacritty**, **Windows Terminal**, can be found in [extras](extras/). To use them, refer to their respective documentation.

--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -118,14 +118,24 @@ M.ristretto = {
   diff_text = '#23324d',
 }
 
-M.highlight = function(group, color)
-  local style = color.style and 'gui=' .. color.style or 'gui=NONE'
-  local fg = color.fg and 'guifg = ' .. color.fg or 'guifg = NONE'
-  local bg = color.bg and 'guibg = ' .. color.bg or 'guibg = NONE'
-  local sp = color.sp and 'guisp = ' .. color.sp or ''
+local function remove_italics(config, colors)
+  if not config.italics and colors.style == 'italic' then
+    colors.style = nil
+  end
+  return colors
+end
+
+local function highlighter(config)
+  return function(group, color)
+    color = remove_italics(config, color)
+    local style = color.style and 'gui=' .. color.style or 'gui=NONE'
+    local fg = color.fg and 'guifg = ' .. color.fg or 'guifg = NONE'
+    local bg = color.bg and 'guibg = ' .. color.bg or 'guibg = NONE'
+    local sp = color.sp and 'guisp = ' .. color.sp or ''
   vim.cmd(
     'highlight ' .. group .. ' ' .. style .. ' ' .. fg .. ' ' .. bg .. ' ' .. sp
   )
+  end
 end
 
 M.load_syntax = function(palette)
@@ -689,6 +699,7 @@ end
 local default_config = {
   palette = M.classic,
   custom_hlgroups = {},
+  italics = true,
 }
 
 M.setup = function(config)
@@ -704,8 +715,9 @@ M.setup = function(config)
   vim.g.colors_name = used_palette.name
   local syntax = M.load_syntax(used_palette)
   syntax = vim.tbl_deep_extend('keep', config.custom_hlgroups, syntax)
+  local highlight = highlighter(config)
   for group, colors in pairs(syntax) do
-    M.highlight(group, colors)
+    highlight(group, colors)
   end
   local plugin_syntax = M.load_plugin_syntax(used_palette)
   plugin_syntax = vim.tbl_deep_extend(
@@ -714,7 +726,7 @@ M.setup = function(config)
     plugin_syntax
   )
   for group, colors in pairs(plugin_syntax) do
-    M.highlight(group, colors)
+    highlight(group, colors)
   end
 end
 


### PR DESCRIPTION
With italics option (true by default), you can disable italic used by default in style for some groups (Function, Keyword, Comment...).

  - README.md : add documentation for italics option
  - lua/monokai.lua : use italics option to disable/enable italic in style

Adapted from https://github.com/tanvirtin/monokai.nvim/pull/18 to fix conflicts.