### PR TITLE
Terminal Using new Treesitter group names

### DIFF
--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -446,129 +446,129 @@ end
 
 M.load_plugin_syntax = function(palette)
   return {
-    TSString = {
+    ["@string"] = {
       fg = palette.yellow,
     },
-    TSInclude = {
+    ["@include"] = {
       fg = palette.pink,
     },
-    TSVariable = {
+    ["@variable"] = {
       fg = palette.white,
     },
-    TSVariableBuiltin = {
+    ["@variable.builtin"] = {
       fg = palette.orange,
     },
-    TSAnnotation = {
+    ["@annotation"] = {
       fg = palette.green,
     },
-    TSComment = {
+    ["@comment"] = {
       fg = palette.base6,
       style = 'italic',
     },
-    TSConstant = {
+    ["@constant"] = {
       fg = palette.aqua,
     },
-    TSConstBuiltin = {
+    ["@const.builtin"] = {
       fg = palette.purple,
     },
-    TSConstMacro = {
+    ["@const.macro"] = {
       fg = palette.purple,
     },
-    TSConstructor = {
+    ["@constructor"] = {
       fg = palette.aqua,
     },
-    TSConditional = {
+    ["@conditional"] = {
       fg = palette.pink,
     },
-    TSCharacter = {
+    ["@character"] = {
       fg = palette.yellow,
     },
-    TSFunction = {
+    ["@function"] = {
       fg = palette.green,
       style = 'italic',
     },
-    TSFuncBuiltin = {
+    ["@func.builtin"] = {
       fg = palette.aqua,
     },
-    TSFuncMacro = {
+    ["@func.macro"] = {
       fg = palette.green,
       style = 'italic',
     },
-    TSKeyword = {
+    ["@keyword"] = {
       fg = palette.pink,
       style = 'italic',
     },
-    TSKeywordFunction = {
+    ["@keyword.function"] = {
       fg = palette.pink,
       style = 'italic',
     },
-    TSKeywordOperator = {
+    ["@keyword.operator"] = {
       fg = palette.pink,
     },
-    TSKeywordReturn = {
+    ["@keyword.return"] = {
       fg = palette.pink,
     },
-    TSMethod = {
+    ["@method"] = {
       fg = palette.green,
     },
-    TSNamespace = {
+    ["@namespace"] = {
       fg = palette.purple,
     },
-    TSNumber = {
+    ["@number"] = {
       fg = palette.purple,
     },
-    TSOperator = {
+    ["@operator"] = {
       fg = palette.pink,
     },
-    TSParameter = {
+    ["@parameter"] = {
       fg = palette.white,
     },
-    TSParameterReference = {
+    ["@parameter.reference"] = {
       fg = palette.white,
     },
-    TSProperty = {
+    ["@property"] = {
       fg = palette.white,
     },
-    TSPunctDelimiter = {
+    ["@punct.delimiter"] = {
       fg = palette.white,
     },
-    TSPunctBracket = {
+    ["@punct.bracket"] = {
       fg = palette.white,
     },
-    TSPunctSpecial = {
+    ["@punct.special"] = {
       fg = palette.pink,
     },
-    TSRepeat = {
+    ["@repeat"] = {
       fg = palette.pink,
     },
-    TSStringRegex = {
+    ["@string.regex"] = {
       fg = palette.purple,
     },
-    TSStringEscape = {
+    ["@string.escape"] = {
       fg = palette.purple,
     },
-    TSTag = {
+    ["@tag"] = {
       fg = palette.pink,
     },
-    TSTagDelimiter = {
+    ["@tag.delimiter"] = {
       fg = palette.white,
     },
-    TSTagAttribute = {
+    ["@tag.attribute"] = {
       fg = palette.green,
     },
-    TSLabel = {
+    ["@label"] = {
       fg = palette.pink,
     },
-    TSType = {
+    ["@type"] = {
       fg = palette.aqua,
     },
-    TSException = {
+    ["@exception"] = {
       fg = palette.pink,
     },
-    TSField = {
+    ["@field"] = {
       fg = palette.white,
     },
-    TSFloat = {
+    ["@float"] = {
       fg = palette.purple,
     },
     dbui_tables = {


### PR DESCRIPTION
As of Oct 15, nvim-treesitter removed the TS* highlight groups. The new groups begin with `@`. See:

https://github.com/nvim-treesitter/nvim-treesitter/issues/2293#issuecomment-1279974776

This PR changes the monokai TS* group names to the `@` names