### PR TITLE
A few color switches

### DIFF
--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -580,7 +580,7 @@ M.load_plugin_syntax = function(palette)
       style = 'italic',
     },
     ["@keyword.function"] = {
-      fg = palette.pink,
+      fg = palette.aqua,
       style = 'italic',
     },
     ["@keyword.operator"] = {

--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -445,31 +445,107 @@ M.load_syntax = function(palette)
 end
 
 M.load_plugin_syntax = function(palette)
+  local math_group = {
+    fg = palette.yellow,
+  }
+  local strike_group = {
+    fg = palette.grey,
+  }
+  local todo_group = {
+    fg = palette.aqua,
+  }
+  local uri_group = {
+    fg = palette.aqua,
+    style = 'underline',
+  }
   return {
     ["@annotation"] = {
       fg = palette.green,
     },
+    ["@attribute"] = {
+      fg = palette.green,
+    },
+    ["@boolean"] = {
+      fg = palette.purple,
+    },
     ["@character"] = {
       fg = palette.yellow,
+    },
+    ["@character.special"] = {
+      fg = palette.purple,
     },
     ["@comment"] = {
       fg = palette.base6,
       style = 'italic',
     },
+    ["@conceal"] = {
+      fg = palette.grey,
+    },
     ["@conditional"] = {
       fg = palette.pink,
     },
-    ["@const.builtin"] = {
-      fg = palette.purple,
-    },
-    ["@const.macro"] = {
-      fg = palette.purple,
+    ["@conditional.ternary"] = {
+      fg = palette.pink,
     },
     ["@constant"] = {
       fg = palette.aqua,
     },
+    ["@constant.builtin"] = {
+      fg = palette.purple,
+    },
+    ["@constant.macro"] = {
+      fg = palette.purple,
+    },
     ["@constructor"] = {
       fg = palette.aqua,
+    },
+    ["@debug"] = {
+      fg = palette.pink,
+    },
+    ["@define"] = {
+      fg = palette.aqua,
+    },
+    ["@definition"] = {
+      fg = palette.green,
+    },
+    ["@definition.associated"] = {
+      fg = palette.green,
+    },
+    ["@definition.constant"] = {
+      fg = palette.green,
+    },
+    ["@definition.enum"] = {
+      fg = palette.green,
+    },
+    ["@definition.field"] = {
+      fg = palette.green,
+    },
+    ["@definition.function"] = {
+      fg = palette.green,
+    },
+    ["@definition.import"] = {
+      fg = palette.white,
+    },
+    ["@definition.macro"] = {
+      fg = palette.green,
+    },
+    ["@definition.method"] = {
+      fg = palette.green,
+    },
+    ["@definition.namespace"] = {
+      fg = palette.white,
+    },
+    ["@definition.parameter"] = {
+      fg = palette.white,
+    },
+    ["@definition.type"] = {
+      fg = palette.green,
+    },
+    ["@definition.var"] = {
+      fg = palette.green,
+    },
+    ["@error"] = {
+      fg = palette.red,
     },
     ["@exception"] = {
       fg = palette.pink,
@@ -486,6 +562,9 @@ M.load_plugin_syntax = function(palette)
     },
     ["@function.builtin"] = {
       fg = palette.aqua,
+    },
+    ["@function.call"] = {
+      fg = palette.white,
     },
     ["@function.macro"] = {
       fg = palette.green,
@@ -511,12 +590,17 @@ M.load_plugin_syntax = function(palette)
     ["@label"] = {
       fg = palette.pink,
     },
+    ["@math"] = math_group,
     ["@method"] = {
       fg = palette.green,
+    },
+    ["@method.call"] = {
+      fg = palette.white,
     },
     ["@namespace"] = {
       fg = palette.purple,
     },
+    -- ["@nospell"] = {},
     ["@number"] = {
       fg = palette.purple,
     },
@@ -528,6 +612,9 @@ M.load_plugin_syntax = function(palette)
     },
     ["@parameter.reference"] = {
       fg = palette.white,
+    },
+    ["@preproc"] = {
+      fg = palette.green,
     },
     ["@property"] = {
       fg = palette.white,
@@ -541,9 +628,23 @@ M.load_plugin_syntax = function(palette)
     ["@punctuation.special"] = {
       fg = palette.pink,
     },
+    ["@reference"] = {
+      fg = palette.white,
+    },
     ["@repeat"] = {
       fg = palette.pink,
     },
+    ["@scope"] = {
+      fg = palette.white,
+    },
+    -- ["@spell"] = {},
+    ["@storageclass"] = {
+      fg = palette.aqua,
+    },
+    ["@storageclass.lifetime"] = {
+      fg = palette.aqua,
+    },
+    ["@strike"] = strike_group,
     ["@string"] = {
       fg = palette.yellow,
     },
@@ -551,6 +652,12 @@ M.load_plugin_syntax = function(palette)
       fg = palette.purple,
     },
     ["@string.regex"] = {
+      fg = palette.purple,
+    },
+    ["@string.special"] = {
+      fg = palette.purple,
+    },
+    ["@symbol"] = {
       fg = palette.purple,
     },
     ["@tag"] = {
@@ -562,9 +669,74 @@ M.load_plugin_syntax = function(palette)
     ["@tag.delimiter"] =  {
       fg = palette.white,
     },
+    ["@text"] = {
+      fg = palette.green,
+    },
+    ["@text.danger"] = {
+      fg = palette.red,
+      style = 'bold',
+    },
+    ["@text.diff.add"] = {
+      fg = palette.diff_add,
+    },
+    ["@text.diff.delete"] = {
+      fg = palette.diff_remove,
+    },
+    ["@text.emphasis"] = {
+      style = 'bold',
+    },
+    ["@text.environment"] = {
+      fg = palette.purple,
+    },
+    ["@text.environment.name"] = {
+      fg = palette.aqua,
+    },
+    ["@text.literal"] = {
+      fg = palette.yellow,
+    },
+    ["@text.math"] = math_group,
+    ["@text.note"] = {
+      fg = palette.aqua,
+      style = 'bold',
+    },
+    ["@text.quote"] = {
+      fg = palette.grey,
+    },
+    ["@text.reference"] = {
+      fg = palette.orange,
+      style = 'italic',
+    },
+    ["@text.strike"] = strike_group,
+    ["@text.strong"] = {
+      style = 'bold',
+    },
+    ["@text.title"] = {
+      fg = palette.yellow,
+      style = 'bold',
+    },
+    ["@text.todo"] = todo_group,
+    ["@text.underline"] = {
+      style = 'underline',
+    },
+    ["@text.uri"] = uri_group,
+    ["@text.warning"] = {
+      fg = palette.yellow,
+      style = 'bold',
+    },
+    ["@todo"] = todo_group,
     ["@type"] = {
       fg = palette.aqua,
     },
+    ["@type.builtin"] = {
+      fg = palette.aqua,
+    },
+    ["@type.definition"] = {
+      fg = palette.aqua,
+    },
+    ["@type.qualifier"] = {
+      fg = palette.pink,
+    },
+    ["@uri"] = uri_group,
     ["@variable"] = {
       fg = palette.white,
     },

--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -446,27 +446,18 @@ end
 
 M.load_plugin_syntax = function(palette)
   return {
-    ["@string"] = {
-      fg = palette.yellow,
-    },
-    ["@include"] = {
-      fg = palette.pink,
-    },
-    ["@variable"] = {
-      fg = palette.white,
-    },
-    ["@variable.builtin"] = {
-      fg = palette.orange,
-    },
     ["@annotation"] = {
       fg = palette.green,
+    },
+    ["@character"] = {
+      fg = palette.yellow,
     },
     ["@comment"] = {
       fg = palette.base6,
       style = 'italic',
     },
-    ["@constant"] = {
-      fg = palette.aqua,
+    ["@conditional"] = {
+      fg = palette.pink,
     },
     ["@const.builtin"] = {
       fg = palette.purple,
@@ -474,14 +465,20 @@ M.load_plugin_syntax = function(palette)
     ["@const.macro"] = {
       fg = palette.purple,
     },
+    ["@constant"] = {
+      fg = palette.aqua,
+    },
     ["@constructor"] = {
       fg = palette.aqua,
     },
-    ["@conditional"] = {
+    ["@exception"] = {
       fg = palette.pink,
     },
-    ["@character"] = {
-      fg = palette.yellow,
+    ["@field"] = {
+      fg = palette.white,
+    },
+    ["@float"] = {
+      fg = palette.purple,
     },
     ["@function"] = {
       fg = palette.green,
@@ -493,6 +490,9 @@ M.load_plugin_syntax = function(palette)
     ["@function.macro"] = {
       fg = palette.green,
       style = 'italic',
+    },
+    ["@include"] = {
+      fg = palette.pink,
     },
     ["@keyword"] = {
       fg = palette.pink,
@@ -506,6 +506,9 @@ M.load_plugin_syntax = function(palette)
       fg = palette.pink,
     },
     ["@keyword.return"] = {
+      fg = palette.pink,
+    },
+    ["@label"] = {
       fg = palette.pink,
     },
     ["@method"] = {
@@ -529,10 +532,10 @@ M.load_plugin_syntax = function(palette)
     ["@property"] = {
       fg = palette.white,
     },
-    ["@punctuation.delimiter"] = {
+    ["@punctuation.bracket"] = {
       fg = palette.white,
     },
-    ["@punctuation.bracket"] = {
+    ["@punctuation.delimiter"] = {
       fg = palette.white,
     },
     ["@punctuation.special"] = {
@@ -541,35 +544,32 @@ M.load_plugin_syntax = function(palette)
     ["@repeat"] = {
       fg = palette.pink,
     },
-    ["@string.regex"] = {
-      fg = palette.purple,
+    ["@string"] = {
+      fg = palette.yellow,
     },
     ["@string.escape"] = {
+      fg = palette.purple,
+    },
+    ["@string.regex"] = {
       fg = palette.purple,
     },
     ["@tag"] = {
       fg = palette.pink,
     },
-    ["@tag.delimiter"] = {
-      fg = palette.white,
-    },
     ["@tag.attribute"] = {
       fg = palette.green,
     },
-    ["@label"] = {
-      fg = palette.pink,
+    ["@tag.delimiter"] =  {
+      fg = palette.white,
     },
     ["@type"] = {
       fg = palette.aqua,
     },
-    ["@exception"] = {
-      fg = palette.pink,
-    },
-    ["@field"] = {
+    ["@variable"] = {
       fg = palette.white,
     },
-    ["@float"] = {
-      fg = palette.purple,
+    ["@variable.builtin"] = {
+      fg = palette.orange,
     },
     dbui_tables = {
       fg = palette.white,

--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -348,7 +348,8 @@ M.load_syntax = function(palette)
       fg = palette.green,
     },
     Include = {
-      fg = palette.pink,
+      fg = palette.aqua,
+      style = 'italic',
     },
     Define = {
       fg = palette.pink,
@@ -571,7 +572,8 @@ M.load_plugin_syntax = function(palette)
       style = 'italic',
     },
     ["@include"] = {
-      fg = palette.pink,
+      fg = palette.aqua,
+      style = 'italic',
     },
     ["@keyword"] = {
       fg = palette.pink,

--- a/lua/monokai.lua
+++ b/lua/monokai.lua
@@ -536,7 +536,7 @@ M.load_plugin_syntax = function(palette)
       fg = palette.white,
     },
     ["@definition.parameter"] = {
-      fg = palette.white,
+      fg = palette.orange,
     },
     ["@definition.type"] = {
       fg = palette.green,
@@ -608,7 +608,7 @@ M.load_plugin_syntax = function(palette)
       fg = palette.pink,
     },
     ["@parameter"] = {
-      fg = palette.white,
+      fg = palette.orange,
     },
     ["@parameter.reference"] = {
       fg = palette.white,


### PR DESCRIPTION
This is on top of https://github.com/tanvirtin/monokai.nvim/pull/35

A few color fixes:
- [Make parameter orange](https://github.com/tanvirtin/monokai.nvim/commit/8e7d8301592d508a9d0dfb3a09fd0a1b7928e921)
- [Make include aqua italic](https://github.com/tanvirtin/monokai.nvim/commit/98959768e5d6ff904c654d61da48c0a8335eb457)
- [Make function keyword aqua](https://github.com/tanvirtin/monokai.nvim/commit/cc7efd0fd8f3a521d805d9d5591f2f1d76e703a2)